### PR TITLE
Directly keep track of taxa associated with peptides

### DIFF
--- a/schemas/structure.sql
+++ b/schemas/structure.sql
@@ -146,8 +146,6 @@ CREATE  TABLE IF NOT EXISTS `unipept`.`sequences` (
   `sequence` VARCHAR(50) NOT NULL ,
   `lca` MEDIUMINT UNSIGNED NULL ,
   `lca_il` MEDIUMINT UNSIGNED NULL ,
-  `fa` BLOB NULL ,
-  `fa_il` BLOB NULL ,
   PRIMARY KEY (`id`) ,
   UNIQUE INDEX `uidx_sequence` (`sequence` ASC) ,
   INDEX `fk_sequences_taxons` (`lca` ASC) ,
@@ -249,6 +247,93 @@ ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8
 COLLATE = utf8_general_ci;
 
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_fa_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `fa` BLOB NULL,
+    PRIMARY KEY (`id`),
+    INDEX `fk_seq_fa_cross_reference_seq_idx` (`seq_id` ASC),
+    CONSTRAINT `fk_seq_fa_cross_reference_seq_id`
+       FOREIGN KEY (`seq_id`)
+           REFERENCES `unipept`.`sequences` (`id`)
+           ON DELETE NO ACTION
+           ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_il_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_fa_il_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `fa_il` BLOB NULL,
+    PRIMARY KEY (`id`),
+    INDEX `fk_seq_fa_il_cross_reference_seq_idx` (`seq_id` ASC),
+    CONSTRAINT `fk_seq_fa_il_cross_reference_seq_id`
+       FOREIGN KEY (`seq_id`)
+           REFERENCES `unipept`.`sequences` (`id`)
+           ON DELETE NO ACTION
+           ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `taxon_id` BLOB NULL,
+    PRIMARY KEY (`id`),
+    INDEX `fk_seq_taxa_cross_reference_seq_idx` (`seq_id` ASC),
+    CONSTRAINT `fk_seq_taxa_cross_reference_seq_id`
+      FOREIGN KEY (`seq_id`)
+          REFERENCES `unipept`.`sequences` (`id`)
+          ON DELETE NO ACTION
+          ON UPDATE NO ACTION,
+    INDEX `fk_seq_taxa_cross_reference_taxa_idx` (`taxon_id` ASC),
+    CONSTRAINT `fk_seq_taxa_cross_reference_taxa_id`
+        FOREIGN KEY (`taxon_id`)
+            REFERENCES `unipept`.`taxons` (`id`)
+            ON DELETE NO ACTION
+            ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_il_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `taxon_id` BLOB NULL,
+    PRIMARY KEY (`id`),
+    INDEX `fk_seq_taxa_il_cross_reference_seq_idx` (`seq_id` ASC),
+    CONSTRAINT `fk_seq_taxa_il_cross_reference_seq_id`
+     FOREIGN KEY (`seq_id`)
+         REFERENCES `unipept`.`sequences` (`id`)
+         ON DELETE NO ACTION
+         ON UPDATE NO ACTION,
+    INDEX `fk_seq_taxa_il_cross_reference_taxa_idx` (`taxon_id` ASC),
+    CONSTRAINT `fk_seq_taxa_il_cross_reference_taxa_id`
+     FOREIGN KEY (`taxon_id`)
+         REFERENCES `unipept`.`taxons` (`id`)
+         ON DELETE NO ACTION
+         ON UPDATE NO ACTION)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
 
 -- -----------------------------------------------------
 -- Table `unipept`.`go_cross_references`

--- a/schemas/structure.sql
+++ b/schemas/structure.sql
@@ -292,7 +292,7 @@ COLLATE = ascii_general_ci;
 CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_cross_references` (
     `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
     `seq_id` INT UNSIGNED NOT NULL,
-    `taxon_id` BLOB NULL,
+    `taxon_id` INT UNSIGNED NOT NULL,
     PRIMARY KEY (`id`),
     INDEX `fk_seq_taxa_cross_reference_seq_idx` (`seq_id` ASC),
     CONSTRAINT `fk_seq_taxa_cross_reference_seq_id`
@@ -317,7 +317,7 @@ COLLATE = ascii_general_ci;
 CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_il_cross_references` (
     `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
     `seq_id` INT UNSIGNED NOT NULL,
-    `taxon_id` BLOB NULL,
+    `taxon_id` INT UNSIGNED NOT NULL,
     PRIMARY KEY (`id`),
     INDEX `fk_seq_taxa_il_cross_reference_seq_idx` (`seq_id` ASC),
     CONSTRAINT `fk_seq_taxa_il_cross_reference_seq_id`

--- a/schemas/structure.sql
+++ b/schemas/structure.sql
@@ -315,6 +315,20 @@ COLLATE = ascii_general_ci;
 
 
 -- -----------------------------------------------------
+-- Table `unipept`.`taxon_cross_references`
+-- -----------------------------------------------------
+CREATE  TABLE IF NOT EXISTS `unipept`.`taxon_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `sequence_id` INT UNSIGNED NOT NULL ,
+    `taxon_id` VARCHAR(9) NOT NULL ,
+    PRIMARY KEY (`id`),
+    INDEX `fk_taxon_reference_sequences` (`sequence_id` ASC))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
 -- Table `unipept`.`users`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `unipept`.`users` (

--- a/schemas/structure_index_only.sql
+++ b/schemas/structure_index_only.sql
@@ -65,6 +65,10 @@ ALTER TABLE ec_cross_references ADD INDEX fk_ec_reference_uniprot_entries (unipr
 -- -----------------------------------------------------
 ALTER TABLE interpro_cross_references ADD INDEX fk_interpro_reference_uniprot_entries (uniprot_entry_id ASC);
 
+-- -----------------------------------------------------
+-- Table `unipept`.`taxon_cross_references`
+-- -----------------------------------------------------
+ALTER TABLE taxon_cross_references ADD INDEX `fk_taxon_reference_sequences` (`sequence_id` ASC);
 
 SET SQL_MODE=@OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;

--- a/schemas/structure_index_only.sql
+++ b/schemas/structure_index_only.sql
@@ -47,6 +47,32 @@ ALTER TABLE peptides ADD INDEX fk_peptides_sequences (sequence_id ASC), ADD INDE
 
 
 -- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_cross_references`
+-- -----------------------------------------------------
+ALTER TABLE seq_fa_cross_references ADD INDEX fk_seq_fa_cross_reference_seq_idx (seq_id ASC);
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_il_cross_references`
+-- -----------------------------------------------------
+ALTER TABLE seq_fa_il_cross_references ADD INDEX fk_seq_fa_il_cross_reference_seq_idx (seq_id ASC);
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_cross_references`
+-- -----------------------------------------------------
+ALTER TABLE seq_taxa_cross_references ADD INDEX fk_seq_taxa_cross_reference_seq_idx (seq_id ASC);
+ALTER TABLE seq_taxa_cross_references ADD INDEX fk_seq_taxa_cross_reference_taxa_idx (taxon_id ASC);
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_il_cross_references`
+-- -----------------------------------------------------
+ALTER TABLE seq_taxa_il_cross_references ADD INDEX fk_seq_taxa_il_cross_reference_seq_idx (seq_id ASC);
+ALTER TABLE seq_taxa_il_cross_references ADD INDEX fk_seq_taxa_il_cross_reference_taxa_idx (taxon_id ASC);
+
+
+-- -----------------------------------------------------
 -- Table `unipept`.`go_cross_references`
 -- -----------------------------------------------------
 ALTER TABLE go_cross_references ADD INDEX fk_go_reference_uniprot_entries (uniprot_entry_id ASC);

--- a/schemas/structure_no_index.sql
+++ b/schemas/structure_no_index.sql
@@ -230,7 +230,7 @@ COLLATE = ascii_general_ci;
 CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_cross_references` (
 `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
 `seq_id` INT UNSIGNED NOT NULL,
-`taxon_id` BLOB NULL,
+`taxon_id` INT UNSIGNED NOT NULL,
 PRIMARY KEY (`id`))
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = ascii
@@ -243,7 +243,7 @@ COLLATE = ascii_general_ci;
 CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_il_cross_references` (
     `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
     `seq_id` INT UNSIGNED NOT NULL,
-    `taxon_id` BLOB NULL,
+    `taxon_id` INT UNSIGNED NOT NULL,
     PRIMARY KEY (`id`))
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = ascii

--- a/schemas/structure_no_index.sql
+++ b/schemas/structure_no_index.sql
@@ -127,8 +127,6 @@ CREATE  TABLE IF NOT EXISTS `unipept`.`sequences` (
   `sequence` VARCHAR(50) NOT NULL ,
   `lca` MEDIUMINT UNSIGNED NULL ,
   `lca_il` MEDIUMINT UNSIGNED NULL ,
-  `fa`  MEDIUMBLOB NULL ,
-  `fa_il`  MEDIUMBLOB NULL ,
   PRIMARY KEY (`id`))
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = ascii
@@ -199,6 +197,57 @@ ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8
 COLLATE = utf8_general_ci;
 
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_fa_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `fa` BLOB NULL,
+    PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_fa_il_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_fa_il_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `fa_il` BLOB NULL,
+    PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_cross_references` (
+`id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+`seq_id` INT UNSIGNED NOT NULL,
+`taxon_id` BLOB NULL,
+PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
+-- Table `unipept`.`seq_taxa_cross_references
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `unipept`.`seq_taxa_il_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `seq_id` INT UNSIGNED NOT NULL,
+    `taxon_id` BLOB NULL,
+    PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
 
 -- -----------------------------------------------------
 -- Table `unipept`.`go_cross_references`

--- a/schemas/structure_no_index.sql
+++ b/schemas/structure_no_index.sql
@@ -239,6 +239,19 @@ COLLATE = ascii_general_ci;
 
 
 -- -----------------------------------------------------
+-- Table `unipept`.`taxon_cross_references`
+-- -----------------------------------------------------
+CREATE  TABLE IF NOT EXISTS `unipept`.`taxon_cross_references` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+    `sequence_id` INT UNSIGNED NOT NULL ,
+    `taxon_id` VARCHAR(9) NOT NULL ,
+    PRIMARY KEY (`id`))
+ENGINE = InnoDB
+DEFAULT CHARACTER SET = ascii
+COLLATE = ascii_general_ci;
+
+
+-- -----------------------------------------------------
 -- Table `unipept`.`users`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `unipept`.`users` (

--- a/scripts/build_database.sh
+++ b/scripts/build_database.sh
@@ -790,8 +790,6 @@ database)
 	pid2=$!
 	wait $pid1
 	wait $pid2
-	rm "$INTDIR/aa_sequence_taxon_equalized.tsv.gz"
-	rm "$INTDIR/aa_sequence_taxon_original.tsv.gz"
 	substitute_equalized_aas
 	rm "$INTDIR/peptides.tsv.gz"
 	substitute_original_aas
@@ -808,6 +806,8 @@ database)
 	rm "$INTDIR/peptides_by_original.tsv.gz"
 	reportProgress "-1" "Creating sequence table." 9
 	create_sequence_tables
+	rm "$INTDIR/aa_sequence_taxon_equalized.tsv.gz"
+  rm "$INTDIR/aa_sequence_taxon_original.tsv.gz"
 	rm "$INTDIR/LCAs_original.tsv.gz"
 	rm "$INTDIR/LCAs_equalized.tsv.gz"
 	rm "$INTDIR/FAs_original.tsv.gz"

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -17,7 +17,7 @@ function print {
 function doCmd {
     echo -n "-> "
     print "$1"
-    echo $1 | mysql -u unipept -punipept unipept 2>&1 | sed "s/^/   /" | grep -v "Using a password on the command line interface can be insecure" | tee -a $logfile
+    echo $1 | mysql --user=unipept --password=unipept unipept 2>&1 | sed "s/^/   /" | grep -v "Using a password on the command line interface can be insecure" | tee -a $logfile
 }
 
 
@@ -44,13 +44,6 @@ doCmd "ALTER TABLE peptides ADD INDEX fk_peptides_sequences (sequence_id ASC);"
 doCmd "ALTER TABLE peptides ADD INDEX fk_peptides_uniprot_entries (uniprot_entry_id ASC);"
 doCmd "ALTER TABLE peptides ADD INDEX fk_peptides_original_sequences (original_sequence_id ASC);"
 
-print "adding index to embl_cross_references"
-doCmd "ALTER TABLE embl_cross_references ADD INDEX fk_embl_reference_uniprot_entries (uniprot_entry_id ASC);"
-# doCmd "ALTER TABLE embl_cross_references ADD INDEX idx_sequence_id (sequence_id ASC);"
-
-print "adding index to refseq_cross_references"
-doCmd "ALTER TABLE refseq_cross_references ADD INDEX fk_refseq_reference_uniprot_entries (uniprot_entry_id ASC);"
-
 print "adding index to go_cross_references"
 doCmd "ALTER TABLE go_cross_references ADD INDEX fk_go_reference_uniprot_entries (uniprot_entry_id ASC);"
 # doCmd "ALTER TABLE go_cross_references ADD INDEX fk_go_cross_reference_go_terms_idx (go_term_code ASC);"
@@ -61,5 +54,19 @@ doCmd "ALTER TABLE ec_cross_references ADD INDEX fk_ec_reference_uniprot_entries
 
 print "adding index to interpro_cross_references"
 doCmd "ALTER TABLE interpro_cross_references ADD INDEX fk_interpro_reference_uniprot_entries (uniprot_entry_id ASC);"
+
+print "adding index to seq_fa_cross_references"
+doCmd "ALTER TABLE seq_fa_cross_references ADD INDEX fk_seq_fa_cross_reference_seq_idx (seq_id ASC)"
+
+print "adding index to seq_fa_il_cross_references"
+doCmd "ALTER TABLE seq_fa_il_cross_references ADD INDEX fk_seq_fa_cross_reference_seq_idx (seq_id ASC)"
+
+print "adding index to seq_taxa_cross_references"
+doCmd "ALTER TABLE seq_taxa_cross_references ADD INDEX fk_seq_taxa_cross_reference_seq_idx (seq_id ASC)"
+doCmd "ALTER TABLE seq_taxa_cross_references ADD INDEX fk_seq_taxa_cross_reference_taxa_idx (taxon_id ASC)"
+
+print "adding index to seq_taxa_il_cross_references"
+doCmd "ALTER TABLE seq_taxa_il_cross_references ADD INDEX fk_seq_taxa_il_cross_reference_seq_idx (seq_id ASC)"
+doCmd "ALTER TABLE seq_taxa_il_cross_references ADD INDEX fk_seq_taxa_il_cross_reference_taxa_idx (taxon_id ASC)"
 
 print "Done"

--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -17,7 +17,7 @@ do
     print $file
     tbl=`echo $file | sed "s/.tsv.gz//"`
     echo "zcatting - LOAD DATA LOCAL INFILE '$file' INTO TABLE $tbl"
-    zcat $file | mysql  --local-infile=1 -uunipept -punipept $db -e "LOAD DATA LOCAL INFILE '/dev/stdin' INTO TABLE $tbl;SHOW WARNINGS" 2>&1
+    gzcat $file | mysql --local-infile=1 --user=unipept --password=unipept $db -e "LOAD DATA LOCAL INFILE '/dev/stdin' INTO TABLE $tbl;SHOW WARNINGS" 2>&1
 done
 print "done"
 


### PR DESCRIPTION
This PR improves the Unipept database by also directly keeping track of which list of taxa is associated with a peptide. This information is currently already available in the database, but can only be extracted by performing a slow series of table `join` operations, which drastically slow the Unipept API down.