### PR TITLE
Fix sequences not getting printed correctly

### DIFF
--- a/scripts/helper_scripts/unipept-database-rs/src/taxons_uniprots_tables/table_writer.rs
+++ b/scripts/helper_scripts/unipept-database-rs/src/taxons_uniprots_tables/table_writer.rs
@@ -130,8 +130,12 @@ impl TableWriter {
 
         writeln!(
             &mut self.peptides,
-            "{}\t{:?}\t{:?}\t{}\t{}",
-            self.peptide_count, sequence, original_sequence, id, annotations
+            "{}\t{}\t{}\t{}\t{}",
+            self.peptide_count,
+            String::from_utf8(sequence)?,
+            String::from_utf8_lossy(original_sequence),
+            id,
+            annotations
         )
         .context("Error writing to TSV")?;
 

--- a/scripts/helper_scripts/unipept-database-rs/src/taxons_uniprots_tables/table_writer.rs
+++ b/scripts/helper_scripts/unipept-database-rs/src/taxons_uniprots_tables/table_writer.rs
@@ -132,7 +132,7 @@ impl TableWriter {
             &mut self.peptides,
             "{}\t{}\t{}\t{}\t{}",
             self.peptide_count,
-            String::from_utf8(sequence)?,
+            String::from_utf8_lossy(&sequence),
             String::from_utf8_lossy(original_sequence),
             id,
             annotations


### PR DESCRIPTION
The sequences were printed as byte vectors instead of the corresponding strings.