### PR TITLE
Update workflow for static database creation

### DIFF
--- a/.github/workflows/static_database.yml
+++ b/.github/workflows/static_database.yml
@@ -44,18 +44,7 @@ jobs:
 
           # Compress the database before uploading it to a Github release
           zip output.zip output.db
-      - name: Update database versioning
-        shell: bash
-        run: |
-          rm workflows/static_database/version.txt
-          echo "${{ steps.date.outputs.date }}" > workflows/static_database/version.txt
-      - name: Update resources
-        uses: test-room-7/action-update-file@v1
-        with:
-          file-path: workflows/static_database/version.txt
-          commit-msg: Bump db version to ${{ steps.date.outputs.date }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get newly made commit sha
+      - name: Get latest made commit sha
         id: commit_sha
         shell: bash
         run: |

--- a/.github/workflows/static_database.yml
+++ b/.github/workflows/static_database.yml
@@ -44,24 +44,12 @@ jobs:
 
           # Compress the database before uploading it to a Github release
           zip output.zip output.db
-      - name: Get latest made commit sha
-        id: commit_sha
-        shell: bash
-        run: |
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
       - name: Create new tag
-        uses: octokit/request-action@v2.x
-        id: create_new_tag
+        uses: rickstaa/action-create-tag@v1
+        id: "tag_create"
         with:
-          route: POST /repos/:owner/:repo/git/tags
-          owner: unipept
-          repo: make-database
           tag: database-${{ steps.date.outputs.date }}
           message: "Static information database built on ${{ steps.date.outputs.date }}"
-          object: ${{ steps.commit_sha.outputs.sha }}
-          type: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
This PR updates the automatic static database creation workflow such that it no longer has to update files in the repository itself. The Unipept Desktop app has been updated earlier to be fully compatible with this change (see https://github.com/unipept/unipept-desktop/releases/tag/v2.0.1)