### PR TITLE
Automatically switch between XML and DAT parser for UniProtKB

### DIFF
--- a/scripts/load.sh
+++ b/scripts/load.sh
@@ -12,10 +12,10 @@ function print {
 
 cd "$dir"
 
-for file in *.tsv.gz
+for file in *.tsv.lz4
 do
     print $file
-    tbl=`echo $file | sed "s/.tsv.gz//"`
+    tbl=`echo $file | sed "s/.tsv.lz4//"`
     echo "zcatting - LOAD DATA LOCAL INFILE '$file' INTO TABLE $tbl"
     zcat $file | mariadb  --local-infile=1 -uunipept -punipept $db -e "LOAD DATA LOCAL INFILE '/dev/stdin' INTO TABLE $tbl;SHOW WARNINGS" 2>&1
 done


### PR DESCRIPTION
UniProtKB is provided in both the XML and DAT file formats. We've implemented a parser for either format and found out (after some benchmarking) that parsing the DAT file is much faster than the XML file. This PR introduces support for automatically switching between these parsers depending on the file type of the UniProtKB resource provided to the `build_database.sh` script.