### PR TITLE
Improve the check for the type of parser that should be used

### DIFF
--- a/scripts/build_database.sh
+++ b/scripts/build_database.sh
@@ -379,6 +379,20 @@ create_taxon_tables() {
 	log "Finished creating the taxon tables."
 }
 
+url_points_to_xml() {
+  URL="$1"
+
+  # Use curl to download the first 1KB of the file and attempt to decompress it
+  # Check if the decompressed output starts with an XML declaration or seems like an XML file
+  if curl -s "$URL" | gunzip | head | grep -q '^<?xml'; then
+    # This is an XML file, return true
+    return 1
+  else
+    # This is not an XML file, return false
+    return 0
+  fi
+}
+
 download_and_convert_all_sources() {
   IDX=0
 
@@ -406,7 +420,7 @@ download_and_convert_all_sources() {
     mkdir -p "$DB_INDEX_OUTPUT"
 
     # The parser that should be used, depends on the filetype of the database that's been provided to this script.
-    if [[ $DB_SOURCE == *xml.gz ]]
+    if [[ $DB_SOURCE == *xml.gz ]] || [[ url_points_to_xml "$DB_SOURCE" ]]
     then
       PARSER="xml-parser"
     elif [[ $DB_SOURCE == *dat.gz ]]

--- a/scripts/build_database.sh
+++ b/scripts/build_database.sh
@@ -385,11 +385,11 @@ url_points_to_xml() {
   # Use curl to download the first 1KB of the file and attempt to decompress it
   # Check if the decompressed output starts with an XML declaration or seems like an XML file
   if curl -s "$URL" | gunzip | head | grep -q '^<?xml'; then
-    # This is an XML file, return true
-    return 1
-  else
-    # This is not an XML file, return false
+    # This is an XML file, success!
     return 0
+  else
+    # This is not an XML file, return non-zero exit code
+    return 1
   fi
 }
 
@@ -420,7 +420,7 @@ download_and_convert_all_sources() {
     mkdir -p "$DB_INDEX_OUTPUT"
 
     # The parser that should be used, depends on the filetype of the database that's been provided to this script.
-    if [[ $DB_SOURCE == *xml.gz ]] || [[ url_points_to_xml "$DB_SOURCE" ]]
+    if [[ $DB_SOURCE == *xml.gz ]] || url_points_to_xml "$DB_SOURCE"
     then
       PARSER="xml-parser"
     elif [[ $DB_SOURCE == *dat.gz ]]

--- a/scripts/build_database.sh
+++ b/scripts/build_database.sh
@@ -382,9 +382,12 @@ create_taxon_tables() {
 url_points_to_xml() {
   URL="$1"
 
+  MATCH=$(curl -s "$URL"| gunzip | head | grep '^<?xml')
+
   # Use curl to download the first 1KB of the file and attempt to decompress it
   # Check if the decompressed output starts with an XML declaration or seems like an XML file
-  if curl -s "$URL" | gunzip | head | grep -q '^<?xml'; then
+  if [[ -n "$MATCH" ]]
+  then
     # This is an XML file, success!
     return 0
   else
@@ -442,7 +445,7 @@ download_and_convert_all_sources() {
 
       reportProgress -1 "Downloading database index for $DB_TYPE." 3
 
-      curl --continue-at - --create-dirs "$DB_SOURCE" --silent | pv -i 5 -n -s "$SIZE" 2> >(reportProgress - "Downloading database index for $DB_TYPE." 3 >&2) | pigz -dc | $CURRENT_LOCATION/helper_scripts/$PARSER -t "$DB_TYPE" | $CURRENT_LOCATION/helper_scripts/write-to-chunk --output-dir "$DB_INDEX_OUTPUT"
+      curl --continue-at - --create-dirs "$DB_SOURCE" --silent | pigz -dc | $CURRENT_LOCATION/helper_scripts/$PARSER -t "$DB_TYPE" | $CURRENT_LOCATION/helper_scripts/write-to-chunk --output-dir "$DB_INDEX_OUTPUT"
 
       # Now, compress the different chunks
       CHUNKS=$(find "$DB_INDEX_OUTPUT" -name "*.chunk")


### PR DESCRIPTION
This PR provides a fix for #47 by effectively looking at the first lines of the file content to decide whether a file is XML or not.