### PR TITLE
Add download of reference proteomes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "apt update && apt -y install curl pv pigz uuid-runtime parallel lz4 gawk",
+  "postCreateCommand": "apt update && apt -y install curl pv pigz uuid-runtime parallel lz4 gawk libxml2-utils",
 
   // Configure tool-specific properties.
   // "customizations": {},

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ scripts/helper_scripts/parser/output
 scripts/helper_scripts/parser/src/META-INF
 .idea/
 *.iml
+index/
+output/
+temp/


### PR DESCRIPTION
This PR adds a new step to the `build_database.sh` script that downloads all reference proteomes from UniProt. These are saved as a `reference_proteomes.lz4.tsv` file with 4 columns: ID, Reference Proteome ID, Taxon ID, Protein count